### PR TITLE
Add ingredient frequency tracking for Trello additions

### DIFF
--- a/src/db/out/0006_add_trello_add_count.sql
+++ b/src/db/out/0006_add_trello_add_count.sql
@@ -1,0 +1,4 @@
+-- Add trello_add_count column to track ingredient frequency
+-- This column tracks how many times each ingredient has been added to Trello
+
+ALTER TABLE ingredients ADD COLUMN trello_add_count integer NOT NULL DEFAULT 0;

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -46,6 +46,7 @@ export const ingredients = pgTable(`ingredients`, {
   fill_level: integer(`fill_level`).notNull().default(0),
   grocery_section: grocerySectionEnum(`grocery_section`).notNull(),
   count: integer(`count`).notNull().default(0),
+  trello_add_count: integer(`trello_add_count`).notNull().default(0),
   expiration_date: timestamp(`expiration_date`, {
     withTimezone: true,
   }).notNull(),

--- a/src/routes/_authenticated/ingredients/index.tsx
+++ b/src/routes/_authenticated/ingredients/index.tsx
@@ -38,9 +38,19 @@ function IngredientsList() {
             .where(({ ingredientsCollection }) =>
               ilike(ingredientsCollection.name, `%${searchQuery}%`)
             )
+            .orderBy(
+              ({ ingredientsCollection }) =>
+                ingredientsCollection.trello_add_count,
+              `desc`
+            )
             .orderBy(({ ingredientsCollection }) => ingredientsCollection.name)
         : q
             .from({ ingredientsCollection })
+            .orderBy(
+              ({ ingredientsCollection }) =>
+                ingredientsCollection.trello_add_count,
+              `desc`
+            )
             .orderBy(({ ingredientsCollection }) => ingredientsCollection.name),
     [searchQuery]
   )
@@ -72,9 +82,13 @@ function IngredientsList() {
         checklists[section].push(ingredient.name)
       })
 
+      // Extract ingredient IDs for tracking
+      const ingredientIds = selectedIngredientsList.map((i) => i.id)
+
       await trpc.shoppingList.addToShoppingList.mutate({
         recipeName: `Manual Ingredients`,
         checklists,
+        ingredientIds,
       })
 
       // Clear selection

--- a/src/routes/api/ingredients.ts
+++ b/src/routes/api/ingredients.ts
@@ -4,10 +4,10 @@ import { prepareElectricUrl, proxyElectricRequest } from "@/lib/electric-proxy"
 
 const serve = async ({ request }: { request: Request }) => {
   try {
-    console.log('Ingredients API called:', request.url)
+    console.log(`Ingredients API called:`, request.url)
 
     const session = await auth.api.getSession({ headers: request.headers })
-    console.log('Session:', session ? 'found' : 'not found')
+    console.log(`Session:`, session ? `found` : `not found`)
 
     if (!session) {
       return new Response(JSON.stringify({ error: `Unauthorized` }), {
@@ -18,21 +18,27 @@ const serve = async ({ request }: { request: Request }) => {
 
     const originUrl = prepareElectricUrl(request.url)
     originUrl.searchParams.set(`table`, `ingredients`)
-    console.log('Electric URL:', originUrl.toString())
+    console.log(`Electric URL:`, originUrl.toString())
 
     // User can only see their own ingredients
     // const filter = `user_id = '${session.user.id}'`
     // originUrl.searchParams.set(`where`, filter)
 
     const response = await proxyElectricRequest(originUrl)
-    console.log('Electric response status:', response.status)
+    console.log(`Electric response status:`, response.status)
     return response
   } catch (error) {
-    console.error('Ingredients API error:', error)
-    return new Response(JSON.stringify({ error: 'Internal server error', details: error.message }), {
-      status: 500,
-      headers: { "content-type": `application/json` },
-    })
+    console.error(`Ingredients API error:`, error)
+    return new Response(
+      JSON.stringify({
+        error: `Internal server error`,
+        details: error.message,
+      }),
+      {
+        status: 500,
+        headers: { "content-type": `application/json` },
+      }
+    )
   }
 }
 


### PR DESCRIPTION
This commit implements tracking of how frequently ingredients are added to Trello shopping lists and sorts the ingredients list by this frequency.

Changes:
- Add trello_add_count field to ingredients schema (defaults to 0)
- Create database migration to add the new field
- Update shopping list mutation to accept ingredient IDs and increment counter
- Modify ingredients list to pass ingredient IDs when adding to shopping list
- Sort ingredients by trello_add_count (descending) then by name

Now ingredients that are added to Trello more frequently will appear at the top of the ingredients list, making it easier to find commonly needed items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)